### PR TITLE
[FEAT/#2] implement auth and user profile API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     //security
-    //implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
     // Swagger openapi-ui
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1'

--- a/src/main/java/com/likelion/nextworld/domain/user/controller/AuthController.java
+++ b/src/main/java/com/likelion/nextworld/domain/user/controller/AuthController.java
@@ -1,0 +1,51 @@
+package com.likelion.nextworld.domain.user.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.likelion.nextworld.domain.user.dto.*;
+import com.likelion.nextworld.domain.user.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+  private final UserService userService;
+
+  @PostMapping("/signup")
+  public ResponseEntity<SignupResponse> signup(@RequestBody SignupRequest request) {
+    SignupResponse response = userService.signup(request);
+    return ResponseEntity.ok(response);
+  }
+
+  @PostMapping("/login")
+  public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
+    LoginResponse response = userService.login(request);
+    return ResponseEntity.ok(response);
+  }
+
+  @PostMapping("/logout")
+  public ResponseEntity<String> logout(@RequestHeader("Authorization") String authHeader) {
+    String token = authHeader.replace("Bearer ", "");
+    userService.logout(token);
+    return ResponseEntity.ok("로그아웃 되었습니다.");
+  }
+
+  @PostMapping("/refresh")
+  public ResponseEntity<String> refresh(@RequestHeader("Refresh-Token") String refreshToken) {
+    String newAccessToken = userService.refresh(refreshToken);
+    return ResponseEntity.ok(newAccessToken);
+  }
+
+  @GetMapping("/me")
+  public ResponseEntity<UserProfileResponse> getMyProfile(
+      @RequestHeader("Authorization") String authHeader) {
+
+    String token = authHeader.replace("Bearer ", "");
+    UserProfileResponse response = userService.getMyProfile(token);
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/com/likelion/nextworld/domain/user/controller/UserController.java
+++ b/src/main/java/com/likelion/nextworld/domain/user/controller/UserController.java
@@ -1,0 +1,28 @@
+package com.likelion.nextworld.domain.user.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.likelion.nextworld.domain.user.dto.UserProfileResponse;
+import com.likelion.nextworld.domain.user.dto.UserProfileUpdateRequest;
+import com.likelion.nextworld.domain.user.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class UserController {
+
+  private final UserService userService;
+
+  @PatchMapping("/me/profile")
+  public ResponseEntity<UserProfileResponse> updateMyProfile(
+      @RequestHeader("Authorization") String authHeader,
+      @RequestBody UserProfileUpdateRequest request) {
+
+    String token = authHeader.replace("Bearer ", "");
+    UserProfileResponse response = userService.updateMyProfile(token, request);
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/com/likelion/nextworld/domain/user/dto/LoginRequest.java
+++ b/src/main/java/com/likelion/nextworld/domain/user/dto/LoginRequest.java
@@ -1,0 +1,11 @@
+package com.likelion.nextworld.domain.user.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequest {
+  private String email;
+  private String password;
+}

--- a/src/main/java/com/likelion/nextworld/domain/user/dto/LoginResponse.java
+++ b/src/main/java/com/likelion/nextworld/domain/user/dto/LoginResponse.java
@@ -1,0 +1,13 @@
+package com.likelion.nextworld.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponse {
+  private String accessToken;
+  private String refreshToken;
+  private String email;
+  private String nickname;
+}

--- a/src/main/java/com/likelion/nextworld/domain/user/dto/SignupRequest.java
+++ b/src/main/java/com/likelion/nextworld/domain/user/dto/SignupRequest.java
@@ -1,0 +1,12 @@
+package com.likelion.nextworld.domain.user.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SignupRequest {
+  private String email;
+  private String password;
+  private String nickname;
+}

--- a/src/main/java/com/likelion/nextworld/domain/user/dto/SignupResponse.java
+++ b/src/main/java/com/likelion/nextworld/domain/user/dto/SignupResponse.java
@@ -1,0 +1,12 @@
+package com.likelion.nextworld.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SignupResponse {
+  private Long userId;
+  private String email;
+  private String nickname;
+}

--- a/src/main/java/com/likelion/nextworld/domain/user/dto/UserProfileResponse.java
+++ b/src/main/java/com/likelion/nextworld/domain/user/dto/UserProfileResponse.java
@@ -1,0 +1,24 @@
+package com.likelion.nextworld.domain.user.dto;
+
+import com.likelion.nextworld.domain.user.entity.User;
+
+import lombok.Getter;
+
+@Getter
+public class UserProfileResponse {
+  private Long userId;
+  private String email;
+  private String nickname;
+  private Long pointsBalance;
+  private Long totalEarned;
+  private String guideline;
+
+  public UserProfileResponse(User user) {
+    this.userId = user.getUserId();
+    this.email = user.getEmail();
+    this.nickname = user.getNickname();
+    this.pointsBalance = user.getPointsBalance();
+    this.totalEarned = user.getTotalEarned();
+    this.guideline = user.getGuideline();
+  }
+}

--- a/src/main/java/com/likelion/nextworld/domain/user/dto/UserProfileUpdateRequest.java
+++ b/src/main/java/com/likelion/nextworld/domain/user/dto/UserProfileUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.likelion.nextworld.domain.user.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserProfileUpdateRequest {
+  private String nickname;
+  private String guideline;
+}

--- a/src/main/java/com/likelion/nextworld/domain/user/entity/User.java
+++ b/src/main/java/com/likelion/nextworld/domain/user/entity/User.java
@@ -1,0 +1,46 @@
+package com.likelion.nextworld.domain.user.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.*;
+
+import lombok.*;
+
+@Entity
+@Table(name = "user")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "user_id")
+  private Long userId; // 사용자ID
+
+  @Column(nullable = false, unique = true)
+  private String email; // 이메일
+
+  @Column(nullable = false)
+  private String password; // 비밀번호
+
+  @Column(nullable = false)
+  private String nickname; // 닉네임
+
+  @Column(name = "points_balance", nullable = false)
+  private Long pointsBalance; // 현재 보유 포인트
+
+  @Column(name = "total_earned", nullable = false)
+  private Long totalEarned; // 누적 수익
+
+  @Column(columnDefinition = "TEXT")
+  private String guideline; // 가이드라인
+
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt; // 가입일
+
+  @Column(name = "updated_at")
+  private LocalDateTime updatedAt; // 수정일
+}

--- a/src/main/java/com/likelion/nextworld/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/likelion/nextworld/domain/user/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.likelion.nextworld.domain.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.likelion.nextworld.domain.user.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+  Optional<User> findByEmail(String email);
+
+  boolean existsByEmail(String email);
+}

--- a/src/main/java/com/likelion/nextworld/domain/user/security/JwtTokenProvider.java
+++ b/src/main/java/com/likelion/nextworld/domain/user/security/JwtTokenProvider.java
@@ -1,0 +1,59 @@
+package com.likelion.nextworld.domain.user.security;
+
+import java.security.Key;
+import java.util.Date;
+
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+
+@Component
+public class JwtTokenProvider {
+
+  private static final String SECRET_KEY =
+      "this_is_a_very_secret_jwt_key_for_nextworld_project_123!";
+  private static final long ACCESS_TOKEN_EXPIRATION = 1000L * 60 * 60;
+  private static final long REFRESH_TOKEN_EXPIRATION = 1000L * 60 * 60 * 24 * 7;
+
+  private final Key key = Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
+
+  // Access Token 생성
+  public String generateAccessToken(String email) {
+    return Jwts.builder()
+        .setSubject(email)
+        .setIssuedAt(new Date())
+        .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRATION))
+        .signWith(key, SignatureAlgorithm.HS256)
+        .compact();
+  }
+
+  // Refresh Token 생성
+  public String generateRefreshToken(String email) {
+    return Jwts.builder()
+        .setSubject(email)
+        .setIssuedAt(new Date())
+        .setExpiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRATION))
+        .signWith(key, SignatureAlgorithm.HS256)
+        .compact();
+  }
+
+  // 토큰 검증
+  public boolean validateToken(String token) {
+    try {
+      Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+      return true;
+    } catch (JwtException | IllegalArgumentException e) {
+      return false;
+    }
+  }
+
+  // 토큰에서 이메일 추출
+  public String getEmailFromToken(String token) {
+    Claims claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+    return claims.getSubject();
+  }
+}

--- a/src/main/java/com/likelion/nextworld/domain/user/security/TokenBlacklist.java
+++ b/src/main/java/com/likelion/nextworld/domain/user/security/TokenBlacklist.java
@@ -1,0 +1,20 @@
+package com.likelion.nextworld.domain.user.security;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class TokenBlacklist {
+
+  private final Set<String> blacklistedTokens = new HashSet<>();
+
+  public void add(String token) {
+    blacklistedTokens.add(token);
+  }
+
+  public boolean contains(String token) {
+    return blacklistedTokens.contains(token);
+  }
+}

--- a/src/main/java/com/likelion/nextworld/domain/user/service/UserService.java
+++ b/src/main/java/com/likelion/nextworld/domain/user/service/UserService.java
@@ -1,0 +1,125 @@
+package com.likelion.nextworld.domain.user.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import com.likelion.nextworld.domain.user.dto.*;
+import com.likelion.nextworld.domain.user.entity.User;
+import com.likelion.nextworld.domain.user.repository.UserRepository;
+import com.likelion.nextworld.domain.user.security.JwtTokenProvider;
+import com.likelion.nextworld.domain.user.security.TokenBlacklist;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+  private final TokenBlacklist tokenBlacklist;
+  private final UserRepository userRepository;
+  private final JwtTokenProvider jwtTokenProvider;
+  private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+  public SignupResponse signup(SignupRequest request) {
+    // 이메일 중복 체크
+    if (userRepository.existsByEmail(request.getEmail())) {
+      throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
+    }
+
+    // 비밀번호 암호화
+    String encodedPassword = passwordEncoder.encode(request.getPassword());
+
+    // 유저 생성 및 저장
+    User user =
+        User.builder()
+            .email(request.getEmail())
+            .password(encodedPassword)
+            .nickname(request.getNickname())
+            .pointsBalance(0L)
+            .totalEarned(0L)
+            .createdAt(LocalDateTime.now())
+            .build();
+
+    userRepository.save(user);
+
+    return new SignupResponse(user.getUserId(), user.getEmail(), user.getNickname());
+  }
+
+  // 로그인
+  public LoginResponse login(LoginRequest request) {
+    User user =
+        userRepository
+            .findByEmail(request.getEmail())
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
+
+    if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+      throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+    }
+
+    String accessToken = jwtTokenProvider.generateAccessToken(user.getEmail());
+    String refreshToken = jwtTokenProvider.generateRefreshToken(user.getEmail());
+
+    return new LoginResponse(accessToken, refreshToken, user.getEmail(), user.getNickname());
+  }
+
+  // 로그아웃 (블랙리스트 등록)
+  public void logout(String token) {
+    if (jwtTokenProvider.validateToken(token)) {
+      tokenBlacklist.add(token);
+    } else {
+      throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+    }
+  }
+
+  // 액세스 토큰 재발급
+  public String refresh(String refreshToken) {
+    if (!jwtTokenProvider.validateToken(refreshToken)) {
+      throw new IllegalArgumentException("만료된 리프레시 토큰입니다.");
+    }
+
+    String email = jwtTokenProvider.getEmailFromToken(refreshToken);
+    return jwtTokenProvider.generateAccessToken(email);
+  }
+
+  // 내 정보 조회
+  public UserProfileResponse getMyProfile(String token) {
+    if (!jwtTokenProvider.validateToken(token)) {
+      throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+    }
+
+    String email = jwtTokenProvider.getEmailFromToken(token);
+    User user =
+        userRepository
+            .findByEmail(email)
+            .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+    return new UserProfileResponse(user);
+  }
+
+  // 프로필 수정
+  public UserProfileResponse updateMyProfile(String token, UserProfileUpdateRequest request) {
+    if (!jwtTokenProvider.validateToken(token)) {
+      throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+    }
+
+    String email = jwtTokenProvider.getEmailFromToken(token);
+    User user =
+        userRepository
+            .findByEmail(email)
+            .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+    if (request.getNickname() != null && !request.getNickname().isBlank()) {
+      user.setNickname(request.getNickname());
+    }
+    if (request.getGuideline() != null) {
+      user.setGuideline(request.getGuideline());
+    }
+
+    user.setUpdatedAt(LocalDateTime.now());
+    userRepository.save(user);
+
+    return new UserProfileResponse(user);
+  }
+}

--- a/src/main/java/com/likelion/nextworld/global/config/SecurityConfig.java
+++ b/src/main/java/com/likelion/nextworld/global/config/SecurityConfig.java
@@ -1,0 +1,32 @@
+package com.likelion.nextworld.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+  private final CorsConfigurationSource corsConfigurationSource;
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http.cors(cors -> cors.configurationSource(corsConfigurationSource)) // ✅ CORS 허용
+        .csrf(csrf -> csrf.disable())
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers("/api/auth/**", "/api/users/**")
+                    .permitAll()
+                    .anyRequest()
+                    .permitAll())
+        .formLogin(form -> form.disable())
+        .httpBasic(basic -> basic.disable());
+
+    return http.build();
+  }
+}


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #2 

## 📝 작업 내용
회원가입 API (POST /api/auth/signup) 구현
로그인 API (POST /api/auth/login) 구현
로그아웃 API (POST /api/auth/logout) 구현
액세스 토큰 재발급 API (POST /api/auth/refresh) 구현
내 계정 정보 조회 API (GET /api/auth/me) 구현
내 프로필 수정 API (PATCH /api/users/me/profile) 구현

## 🛠 개발 상세
- JWT 기반 인증 로직 구현 (JwtTokenProvider)
- Spring Security 및 CORS 설정 추가 (SecurityConfig, CorsConfig)
- TokenBlacklist 를 이용한 로그아웃 처리 로직 구현
- User 엔티티 및 Repository 구성 (users 테이블 자동 생성)
- Postman으로 전체 엔드포인트 테스트 완료 (200 OK 확인)

## ✔️ 체크 리스트
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?