### PR TITLE
[FEAT/#6] 결제 및 수익분배

### DIFF
--- a/src/main/java/com/likelion/nextworld/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/likelion/nextworld/domain/mypage/controller/MyPageController.java
@@ -1,0 +1,35 @@
+package com.likelion.nextworld.domain.mypage.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.likelion.nextworld.domain.mypage.service.MyPageService;
+import com.likelion.nextworld.domain.payment.dto.PayItemResponse;
+import com.likelion.nextworld.domain.payment.dto.PointsResponse;
+import com.likelion.nextworld.domain.user.security.UserPrincipal;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/mypage")
+@RequiredArgsConstructor
+public class MyPageController {
+
+  private final MyPageService myPageService;
+
+  @GetMapping("/points")
+  public ResponseEntity<PointsResponse> points(@AuthenticationPrincipal UserPrincipal user) {
+    return ResponseEntity.ok(myPageService.myPoints(user));
+  }
+
+  @GetMapping("/paylist")
+  public ResponseEntity<List<PayItemResponse>> paylist(
+      @AuthenticationPrincipal UserPrincipal user) {
+    return ResponseEntity.ok(myPageService.myPayList(user));
+  }
+}

--- a/src/main/java/com/likelion/nextworld/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/likelion/nextworld/domain/mypage/service/MyPageService.java
@@ -1,0 +1,33 @@
+package com.likelion.nextworld.domain.mypage.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.likelion.nextworld.domain.payment.dto.PayItemResponse;
+import com.likelion.nextworld.domain.payment.dto.PointsResponse;
+import com.likelion.nextworld.domain.payment.service.PaymentService;
+import com.likelion.nextworld.domain.user.entity.User;
+import com.likelion.nextworld.domain.user.repository.UserRepository;
+import com.likelion.nextworld.domain.user.security.UserPrincipal;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+  private final UserRepository userRepository;
+  private final PaymentService paymentService;
+
+  public PointsResponse myPoints(UserPrincipal principal) {
+    User me =
+        userRepository
+            .findById(principal.getId())
+            .orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
+    return new PointsResponse(me.getPointsBalance());
+  }
+
+  public List<PayItemResponse> myPayList(UserPrincipal principal) {
+    return paymentService.myPayList(principal);
+  }
+}

--- a/src/main/java/com/likelion/nextworld/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/likelion/nextworld/domain/payment/controller/PaymentController.java
@@ -1,0 +1,45 @@
+package com.likelion.nextworld.domain.payment.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.likelion.nextworld.domain.payment.dto.ChargeRequest;
+import com.likelion.nextworld.domain.payment.dto.UseRequest;
+import com.likelion.nextworld.domain.payment.dto.VerifyRequest;
+import com.likelion.nextworld.domain.payment.service.PaymentService;
+import com.likelion.nextworld.domain.user.security.UserPrincipal;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/payment")
+@RequiredArgsConstructor
+public class PaymentController {
+
+  private final PaymentService paymentService;
+
+  @PostMapping("/charge")
+  public ResponseEntity<Void> charge(
+      @AuthenticationPrincipal UserPrincipal user, @RequestBody ChargeRequest req) {
+    paymentService.charge(user, req);
+    return ResponseEntity.ok().build();
+  }
+
+  @PostMapping("/verify")
+  public ResponseEntity<Boolean> verify(
+      @AuthenticationPrincipal UserPrincipal user, @RequestBody VerifyRequest req) {
+    boolean ok = paymentService.verify(user, req);
+    return ResponseEntity.ok(ok);
+  }
+
+  @PostMapping("/use")
+  public ResponseEntity<Void> use(
+      @AuthenticationPrincipal UserPrincipal user, @RequestBody UseRequest req) {
+    paymentService.use(user, req);
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/com/likelion/nextworld/domain/payment/dto/ChargeRequest.java
+++ b/src/main/java/com/likelion/nextworld/domain/payment/dto/ChargeRequest.java
@@ -1,0 +1,9 @@
+package com.likelion.nextworld.domain.payment.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ChargeRequest {
+  private String impUid;
+  private Long amount;
+}

--- a/src/main/java/com/likelion/nextworld/domain/payment/dto/PayItemResponse.java
+++ b/src/main/java/com/likelion/nextworld/domain/payment/dto/PayItemResponse.java
@@ -1,0 +1,20 @@
+package com.likelion.nextworld.domain.payment.dto;
+
+import java.time.LocalDateTime;
+
+import com.likelion.nextworld.domain.payment.entity.PayStatus;
+import com.likelion.nextworld.domain.payment.entity.TransactionType;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PayItemResponse {
+  private Long payId;
+  private Long amount;
+  private TransactionType type;
+  private PayStatus status;
+  private String impUid;
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/com/likelion/nextworld/domain/payment/dto/PointsResponse.java
+++ b/src/main/java/com/likelion/nextworld/domain/payment/dto/PointsResponse.java
@@ -1,0 +1,10 @@
+package com.likelion.nextworld.domain.payment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PointsResponse {
+  private Long balance;
+}

--- a/src/main/java/com/likelion/nextworld/domain/payment/dto/UseRequest.java
+++ b/src/main/java/com/likelion/nextworld/domain/payment/dto/UseRequest.java
@@ -1,0 +1,10 @@
+package com.likelion.nextworld.domain.payment.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UseRequest {
+  private Long amount;
+  private Long derivativeWorkId;
+  private Long authorId;
+}

--- a/src/main/java/com/likelion/nextworld/domain/payment/dto/VerifyRequest.java
+++ b/src/main/java/com/likelion/nextworld/domain/payment/dto/VerifyRequest.java
@@ -1,0 +1,8 @@
+package com.likelion.nextworld.domain.payment.dto;
+
+import lombok.Getter;
+
+@Getter
+public class VerifyRequest {
+  private String impUid;
+}

--- a/src/main/java/com/likelion/nextworld/domain/payment/entity/Pay.java
+++ b/src/main/java/com/likelion/nextworld/domain/payment/entity/Pay.java
@@ -1,0 +1,50 @@
+package com.likelion.nextworld.domain.payment.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.*;
+
+import com.likelion.nextworld.domain.user.entity.User;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class Pay {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long payId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "payer_id", nullable = false)
+  private User payer;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "author_id")
+  private User author;
+
+  @Column(nullable = false)
+  private Long amount;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private TransactionType transactionType; // CHARGE/USE/REFUND
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private PayStatus payStatus; // PENDING/COMPLETED/FAILED
+
+  @Column(unique = true)
+  private String impUid;
+
+  private LocalDateTime createdAt;
+
+  @PrePersist
+  void prePersist() {
+    if (createdAt == null) createdAt = LocalDateTime.now();
+  }
+}

--- a/src/main/java/com/likelion/nextworld/domain/payment/entity/PayStatus.java
+++ b/src/main/java/com/likelion/nextworld/domain/payment/entity/PayStatus.java
@@ -1,0 +1,7 @@
+package com.likelion.nextworld.domain.payment.entity;
+
+public enum PayStatus {
+  PENDING,
+  COMPLETED,
+  FAILED
+}

--- a/src/main/java/com/likelion/nextworld/domain/payment/entity/TransactionType.java
+++ b/src/main/java/com/likelion/nextworld/domain/payment/entity/TransactionType.java
@@ -1,0 +1,7 @@
+package com.likelion.nextworld.domain.payment.entity;
+
+public enum TransactionType {
+  CHARGE,
+  USE,
+  REFUND
+}

--- a/src/main/java/com/likelion/nextworld/domain/payment/repository/PayRepository.java
+++ b/src/main/java/com/likelion/nextworld/domain/payment/repository/PayRepository.java
@@ -1,0 +1,18 @@
+package com.likelion.nextworld.domain.payment.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.likelion.nextworld.domain.payment.entity.Pay;
+import com.likelion.nextworld.domain.payment.entity.PayStatus;
+import com.likelion.nextworld.domain.user.entity.User;
+
+public interface PayRepository extends JpaRepository<Pay, Long> {
+  List<Pay> findByPayerOrderByCreatedAtDesc(User payer);
+
+  Optional<Pay> findByImpUid(String impUid);
+
+  List<Pay> findByPayerAndPayStatusOrderByCreatedAtDesc(User payer, PayStatus status);
+}

--- a/src/main/java/com/likelion/nextworld/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/likelion/nextworld/domain/payment/service/PaymentService.java
@@ -1,0 +1,115 @@
+package com.likelion.nextworld.domain.payment.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.likelion.nextworld.domain.payment.dto.ChargeRequest;
+import com.likelion.nextworld.domain.payment.dto.PayItemResponse;
+import com.likelion.nextworld.domain.payment.dto.UseRequest;
+import com.likelion.nextworld.domain.payment.dto.VerifyRequest;
+import com.likelion.nextworld.domain.payment.entity.Pay;
+import com.likelion.nextworld.domain.payment.entity.PayStatus;
+import com.likelion.nextworld.domain.payment.entity.TransactionType;
+import com.likelion.nextworld.domain.payment.repository.PayRepository;
+import com.likelion.nextworld.domain.user.entity.User;
+import com.likelion.nextworld.domain.user.repository.UserRepository;
+import com.likelion.nextworld.domain.user.security.UserPrincipal;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+  private final PayRepository payRepository;
+  private final UserRepository userRepository;
+  private final PortOneClient portOneClient;
+
+  @Transactional
+  public void charge(UserPrincipal principal, ChargeRequest req) {
+    User payer = getUser(principal.getId());
+
+    payRepository
+        .findByImpUid(req.getImpUid())
+        .ifPresent(
+            p -> {
+              throw new IllegalStateException("이미 처리된 결제입니다.");
+            });
+
+    // 1) PENDING 기록
+    Pay pay =
+        Pay.builder()
+            .payer(payer)
+            .amount(req.getAmount())
+            .transactionType(TransactionType.CHARGE)
+            .payStatus(PayStatus.PENDING)
+            .impUid(req.getImpUid())
+            .build();
+    payRepository.save(pay);
+  }
+
+  @Transactional
+  public boolean verify(UserPrincipal principal, VerifyRequest req) {
+    User payer = getUser(principal.getId());
+
+    Pay pay =
+        payRepository
+            .findByImpUid(req.getImpUid())
+            .orElseThrow(() -> new IllegalArgumentException("해당 impUid로 생성된 결제가 없습니다."));
+
+    // 2) PortOne 서버 검증
+    PortOneClient.PaymentLookup lookup = portOneClient.lookup(req.getImpUid());
+    if (!"paid".equalsIgnoreCase(lookup.getResponse().getStatus()))
+      throw new IllegalStateException("결제가 승인되지 않았습니다.");
+
+    Long paidAmount = lookup.getResponse().getAmount();
+    if (!paidAmount.equals(pay.getAmount())) throw new IllegalStateException("금액 불일치");
+
+    // 3) 사용자 포인트 적립 + 상태 갱신
+    payer.setPointsBalance(payer.getPointsBalance() + paidAmount);
+    pay.setPayStatus(PayStatus.COMPLETED);
+
+    return true;
+  }
+
+  @Transactional
+  public void use(UserPrincipal principal, UseRequest req) {
+    User payer = getUser(principal.getId());
+    if (payer.getPointsBalance() < req.getAmount()) throw new IllegalStateException("포인트가 부족합니다.");
+
+    payer.setPointsBalance(payer.getPointsBalance() - req.getAmount());
+
+    User author = (req.getAuthorId() != null) ? getUser(req.getAuthorId()) : null;
+
+    Pay pay =
+        Pay.builder()
+            .payer(payer)
+            .author(author)
+            .amount(req.getAmount())
+            .transactionType(TransactionType.USE)
+            .payStatus(PayStatus.COMPLETED)
+            .build();
+    payRepository.save(pay);
+  }
+
+  public List<PayItemResponse> myPayList(UserPrincipal principal) {
+    User me = getUser(principal.getId());
+    return payRepository.findByPayerOrderByCreatedAtDesc(me).stream()
+        .map(
+            p ->
+                PayItemResponse.builder()
+                    .payId(p.getPayId())
+                    .amount(p.getAmount())
+                    .type(p.getTransactionType())
+                    .status(p.getPayStatus())
+                    .impUid(p.getImpUid())
+                    .createdAt(p.getCreatedAt())
+                    .build())
+        .toList();
+  }
+
+  private User getUser(Long id) {
+    return userRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
+  }
+}

--- a/src/main/java/com/likelion/nextworld/domain/payment/service/PortOneClient.java
+++ b/src/main/java/com/likelion/nextworld/domain/payment/service/PortOneClient.java
@@ -1,0 +1,68 @@
+package com.likelion.nextworld.domain.payment.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PortOneClient {
+
+  private final WebClient webClient = WebClient.builder().baseUrl("https://api.iamport.kr").build();
+
+  @Value("${portone.api_key}")
+  private String apiKey;
+
+  @Value("${portone.api_secret}")
+  private String apiSecret;
+
+  public String getAccessToken() {
+    return webClient
+        .post()
+        .uri("/users/getToken")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(String.format("{\"imp_key\":\"%s\",\"imp_secret\":\"%s\"}", apiKey, apiSecret))
+        .retrieve()
+        .bodyToMono(TokenResponse.class)
+        .block()
+        .getResponse()
+        .getAccess_token();
+  }
+
+  public PaymentLookup lookup(String impUid) {
+    String token = getAccessToken();
+    return webClient
+        .get()
+        .uri("/payments/{impUid}", impUid)
+        .header("Authorization", token)
+        .retrieve()
+        .bodyToMono(PaymentLookup.class)
+        .block();
+  }
+
+  @lombok.Getter
+  static class TokenResponse {
+    Inner response;
+
+    @lombok.Getter
+    static class Inner {
+      String access_token;
+    }
+  }
+
+  @lombok.Getter
+  public static class PaymentLookup {
+    Inner response;
+
+    @lombok.Getter
+    public static class Inner {
+      String status; // paid, ready, failed ...
+      Long amount;
+      String imp_uid;
+      String merchant_uid;
+    }
+  }
+}

--- a/src/main/java/com/likelion/nextworld/domain/post/entity/DerivativeWork.java
+++ b/src/main/java/com/likelion/nextworld/domain/post/entity/DerivativeWork.java
@@ -1,12 +1,14 @@
 package com.likelion.nextworld.domain.post.entity;
 
-import com.likelion.nextworld.domain.user.entity.User;
-import jakarta.persistence.*;
-import lombok.*;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+
+import jakarta.persistence.*;
+
+import com.likelion.nextworld.domain.user.entity.User;
+
+import lombok.*;
 
 @Entity
 @Getter
@@ -15,50 +17,52 @@ import java.util.List;
 @Builder
 public class DerivativeWork {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    @Setter
-    private String title;
+  @Setter private String title;
 
-    @Setter
-    @Column(columnDefinition = "TEXT")
-    private String content;
+  @Setter
+  @Column(columnDefinition = "TEXT")
+  private String content;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User author;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private User author;
 
-    @Enumerated(EnumType.STRING)
-    private WorkStatus status; // DRAFT or PUBLISHED
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "dauthor_id")
+  private User dAuthor;
 
-    @Enumerated(EnumType.STRING)
-    private WorkType workType; // SHORT, SERIALIZED
+  @Enumerated(EnumType.STRING)
+  private WorkStatus status; // DRAFT or PUBLISHED
 
-    @Enumerated(EnumType.STRING)
-    private CreationType creationType; // ORIGINAL, DERIVATIVE
+  @Enumerated(EnumType.STRING)
+  private WorkType workType; // SHORT, SERIALIZED
 
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+  @Enumerated(EnumType.STRING)
+  private CreationType creationType; // ORIGINAL, DERIVATIVE
 
-    @PrePersist
-    public void onCreate() {
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
-        if (this.status == null) this.status = WorkStatus.DRAFT;
-    }
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
 
-    @PreUpdate
-    public void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
-    }
+  @PrePersist
+  public void onCreate() {
+    this.createdAt = LocalDateTime.now();
+    this.updatedAt = LocalDateTime.now();
+    if (this.status == null) this.status = WorkStatus.DRAFT;
+  }
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "parent_id")
-    private DerivativeWork parentWork;  //부모 작품 (1차 창작물)
+  @PreUpdate
+  public void onUpdate() {
+    this.updatedAt = LocalDateTime.now();
+  }
 
-    @OneToMany(mappedBy = "parentWork", cascade = CascadeType.ALL)
-    private List<DerivativeWork> childWorks = new ArrayList<>(); // 파생된 2차 창작물들
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "parent_id")
+  private DerivativeWork parentWork; // 부모 작품 (1차 창작물)
 
+  @OneToMany(mappedBy = "parentWork", cascade = CascadeType.ALL)
+  private List<DerivativeWork> childWorks = new ArrayList<>(); // 파생된 2차 창작물들
 }

--- a/src/main/java/com/likelion/nextworld/domain/revenue/controller/RevenueController.java
+++ b/src/main/java/com/likelion/nextworld/domain/revenue/controller/RevenueController.java
@@ -1,0 +1,4 @@
+package com.likelion.nextworld.domain.revenue.controller;
+
+public class RevenueController {
+}

--- a/src/main/java/com/likelion/nextworld/domain/revenue/entity/RevenueShare.java
+++ b/src/main/java/com/likelion/nextworld/domain/revenue/entity/RevenueShare.java
@@ -1,0 +1,4 @@
+package com.likelion.nextworld.domain.revenue.entity;
+
+public class RevenueShare {
+}

--- a/src/main/java/com/likelion/nextworld/domain/revenue/repository/RevenueShareRepository.java
+++ b/src/main/java/com/likelion/nextworld/domain/revenue/repository/RevenueShareRepository.java
@@ -1,0 +1,4 @@
+package com.likelion.nextworld.domain.revenue.repository;
+
+public class RevenueShareRepository {
+}

--- a/src/main/java/com/likelion/nextworld/domain/revenue/service/RevenueService.java
+++ b/src/main/java/com/likelion/nextworld/domain/revenue/service/RevenueService.java
@@ -1,0 +1,4 @@
+package com.likelion.nextworld.domain.payment.service;
+
+public class RevenueService {
+}


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #6 

## 📝 작업 내용
- 포인트 충전, 사용, 검증 API 구현
- 마이페이지 내 포인트 조회 및 결제 내역 조회 기능 추가
- 수익 분배 로직 구현 (작가 40%, 2차 창작자 30%, 관리자 30%)
- 포트원(PortOne) 샌드박스 연동을 통한 결제 검증 로직 추가

## 🛠 개발 상세
- `PortOneClient`를 통한 외부 PG사(PortOne) API 연동 구조 구현
- 결제 성공 시 포인트 적립 및 RevenueShare 분배 자동 반영

## ✔️ 체크 리스트
- [x] 로컬 환경에서 애플리케이션 정상 구동 확인

## ➕ 추후 계획(선택)
- 프론트엔드 연동 후 실제 결제 플로우 테스트 진행 예정