### PR TITLE
[FEAT/#11] 관리자 승인 기반 환불

### DIFF
--- a/src/main/java/com/likelion/nextworld/domain/payment/controller/AdminPaymentController.java
+++ b/src/main/java/com/likelion/nextworld/domain/payment/controller/AdminPaymentController.java
@@ -1,0 +1,30 @@
+package com.likelion.nextworld.domain.payment.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.likelion.nextworld.domain.payment.dto.PayItemResponse;
+import com.likelion.nextworld.domain.payment.service.AdminPaymentService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/admin/payments")
+@RequiredArgsConstructor
+public class AdminPaymentController {
+
+  private final AdminPaymentService adminPaymentService;
+
+  @GetMapping
+  public ResponseEntity<List<PayItemResponse>> getRefundRequests() {
+    return ResponseEntity.ok(adminPaymentService.getRefundRequests());
+  }
+
+  @PatchMapping("/{payId}/refund")
+  public ResponseEntity<String> approveRefund(@PathVariable Long payId) {
+    adminPaymentService.approveRefund(payId);
+    return ResponseEntity.ok("환불이 완료되었습니다.");
+  }
+}

--- a/src/main/java/com/likelion/nextworld/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/likelion/nextworld/domain/payment/controller/PaymentController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.likelion.nextworld.domain.payment.dto.ChargeRequest;
+import com.likelion.nextworld.domain.payment.dto.RefundRequest;
 import com.likelion.nextworld.domain.payment.dto.UseRequest;
 import com.likelion.nextworld.domain.payment.dto.VerifyRequest;
 import com.likelion.nextworld.domain.payment.service.PaymentService;
@@ -41,5 +42,12 @@ public class PaymentController {
       @AuthenticationPrincipal UserPrincipal user, @RequestBody UseRequest req) {
     paymentService.use(user, req);
     return ResponseEntity.ok().build();
+  }
+
+  @PostMapping("/refund")
+  public ResponseEntity<String> requestRefund(
+      @AuthenticationPrincipal UserPrincipal user, @RequestBody RefundRequest request) {
+    paymentService.requestRefund(request, user.getId());
+    return ResponseEntity.ok("환불 요청이 접수되었습니다. 관리자의 승인을 기다려주세요.");
   }
 }

--- a/src/main/java/com/likelion/nextworld/domain/payment/dto/RefundRequest.java
+++ b/src/main/java/com/likelion/nextworld/domain/payment/dto/RefundRequest.java
@@ -1,0 +1,12 @@
+package com.likelion.nextworld.domain.payment.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RefundRequest {
+  private String impUid;
+  private int amount;
+  private String reason;
+}

--- a/src/main/java/com/likelion/nextworld/domain/payment/entity/Pay.java
+++ b/src/main/java/com/likelion/nextworld/domain/payment/entity/Pay.java
@@ -47,4 +47,8 @@ public class Pay {
   void prePersist() {
     if (createdAt == null) createdAt = LocalDateTime.now();
   }
+
+  public void setStatus(PayStatus status) {
+    this.payStatus = status;
+  }
 }

--- a/src/main/java/com/likelion/nextworld/domain/payment/entity/PayStatus.java
+++ b/src/main/java/com/likelion/nextworld/domain/payment/entity/PayStatus.java
@@ -3,5 +3,7 @@ package com.likelion.nextworld.domain.payment.entity;
 public enum PayStatus {
   PENDING,
   COMPLETED,
-  FAILED
+  FAILED,
+  REFUND_REQUESTED,
+  REFUNDED
 }

--- a/src/main/java/com/likelion/nextworld/domain/payment/repository/PayRepository.java
+++ b/src/main/java/com/likelion/nextworld/domain/payment/repository/PayRepository.java
@@ -15,4 +15,6 @@ public interface PayRepository extends JpaRepository<Pay, Long> {
   Optional<Pay> findByImpUid(String impUid);
 
   List<Pay> findByPayerAndPayStatusOrderByCreatedAtDesc(User payer, PayStatus status);
+
+  List<Pay> findByPayStatus(PayStatus status);
 }

--- a/src/main/java/com/likelion/nextworld/domain/payment/service/AdminPaymentService.java
+++ b/src/main/java/com/likelion/nextworld/domain/payment/service/AdminPaymentService.java
@@ -1,0 +1,63 @@
+package com.likelion.nextworld.domain.payment.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.likelion.nextworld.domain.payment.dto.PayItemResponse;
+import com.likelion.nextworld.domain.payment.entity.Pay;
+import com.likelion.nextworld.domain.payment.entity.PayStatus;
+import com.likelion.nextworld.domain.payment.repository.PayRepository;
+import com.likelion.nextworld.domain.user.entity.User;
+import com.likelion.nextworld.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminPaymentService {
+
+  private final PayRepository payRepository;
+  private final UserRepository userRepository;
+  private final PortOneClient portOneClient;
+
+  @Transactional
+  public void approveRefund(Long payId) {
+    Pay pay =
+        payRepository
+            .findById(payId)
+            .orElseThrow(() -> new IllegalArgumentException("결제 내역을 찾을 수 없습니다."));
+
+    if (pay.getPayStatus() != PayStatus.REFUND_REQUESTED) {
+      throw new IllegalStateException("환불 요청 상태가 아닙니다.");
+    }
+
+    // PortOne 환불 요청
+    portOneClient.refundPayment(pay.getImpUid(), pay.getAmount().intValue(), "관리자 승인 환불");
+
+    // 결제 상태 변경
+    pay.setStatus(PayStatus.REFUNDED);
+    payRepository.save(pay);
+
+    // 사용자 포인트 차감
+    User user = pay.getPayer();
+    user.decreasePoints(pay.getAmount());
+  }
+
+  @Transactional(readOnly = true)
+  public List<PayItemResponse> getRefundRequests() {
+    return payRepository.findByPayStatus(PayStatus.REFUND_REQUESTED).stream()
+        .map(
+            p ->
+                PayItemResponse.builder()
+                    .payId(p.getPayId())
+                    .amount(p.getAmount())
+                    .type(p.getTransactionType())
+                    .status(p.getPayStatus())
+                    .impUid(p.getImpUid())
+                    .createdAt(p.getCreatedAt())
+                    .build())
+        .toList();
+  }
+}

--- a/src/main/java/com/likelion/nextworld/domain/revenue/controller/RevenueController.java
+++ b/src/main/java/com/likelion/nextworld/domain/revenue/controller/RevenueController.java
@@ -1,4 +1,32 @@
 package com.likelion.nextworld.domain.revenue.controller;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.likelion.nextworld.domain.revenue.service.RevenueService;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/revenue")
+@RequiredArgsConstructor
 public class RevenueController {
+
+  private final RevenueService revenueService;
+
+  @PostMapping("/distribute")
+  public ResponseEntity<Void> distribute(@RequestBody DistributeRequest req) {
+    revenueService.distribute(req.getPayId(), req.getDerivativeWorkId());
+    return ResponseEntity.ok().build();
+  }
+
+  @Getter
+  static class DistributeRequest {
+    private Long payId;
+    private Long derivativeWorkId;
+  }
 }

--- a/src/main/java/com/likelion/nextworld/domain/revenue/entity/RevenueShare.java
+++ b/src/main/java/com/likelion/nextworld/domain/revenue/entity/RevenueShare.java
@@ -1,4 +1,43 @@
 package com.likelion.nextworld.domain.revenue.entity;
 
+import java.time.LocalDateTime;
+
+import jakarta.persistence.*;
+
+import com.likelion.nextworld.domain.payment.entity.Pay;
+import com.likelion.nextworld.domain.user.entity.User;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
 public class RevenueShare {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long revenueId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "pay_id", nullable = false)
+  private Pay pay;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "author_id", nullable = false)
+  private User author;
+
+  @Column(nullable = false)
+  private Long shareAmount;
+
+  private LocalDateTime distributedAt;
+
+  @PrePersist
+  void prePersist() {
+    if (distributedAt == null) {
+      distributedAt = LocalDateTime.now();
+    }
+  }
 }

--- a/src/main/java/com/likelion/nextworld/domain/revenue/repository/RevenueShareRepository.java
+++ b/src/main/java/com/likelion/nextworld/domain/revenue/repository/RevenueShareRepository.java
@@ -1,4 +1,7 @@
 package com.likelion.nextworld.domain.revenue.repository;
 
-public class RevenueShareRepository {
-}
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.likelion.nextworld.domain.revenue.entity.RevenueShare;
+
+public interface RevenueShareRepository extends JpaRepository<RevenueShare, Long> {}

--- a/src/main/java/com/likelion/nextworld/domain/revenue/service/RevenueService.java
+++ b/src/main/java/com/likelion/nextworld/domain/revenue/service/RevenueService.java
@@ -1,4 +1,74 @@
-package com.likelion.nextworld.domain.payment.service;
+package com.likelion.nextworld.domain.revenue.service;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.likelion.nextworld.domain.payment.entity.Pay;
+import com.likelion.nextworld.domain.payment.repository.PayRepository;
+import com.likelion.nextworld.domain.post.entity.DerivativeWork;
+import com.likelion.nextworld.domain.post.repository.DerivativeWorkRepository;
+import com.likelion.nextworld.domain.revenue.entity.RevenueShare;
+import com.likelion.nextworld.domain.revenue.repository.RevenueShareRepository;
+import com.likelion.nextworld.domain.user.entity.User;
+import com.likelion.nextworld.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
 public class RevenueService {
+
+  private final PayRepository payRepository;
+  private final RevenueShareRepository revenueShareRepository;
+  private final DerivativeWorkRepository derivativeWorkRepository;
+  private final UserRepository userRepository;
+
+  /** 수익 분배: 작가 40%, 2차 창작자 30%, 플랫폼 관리자 30% */
+  @Transactional
+  public void distribute(Long payId, Long derivativeWorkId) {
+
+    Pay pay =
+        payRepository.findById(payId).orElseThrow(() -> new IllegalArgumentException("결제 내역 없음"));
+
+    // 2차 창작물 정보
+    DerivativeWork work =
+        derivativeWorkRepository
+            .findById(derivativeWorkId)
+            .orElseThrow(() -> new IllegalArgumentException("2차 창작물 없음"));
+
+    // 1차 창작자
+    User originalAuthor = work.getAuthor();
+
+    // 2차 창작자
+    User derivativeAuthor = work.getDAuthor();
+
+    // 플랫폼 관리자 (id=1)
+    User platformAdmin =
+        userRepository
+            .findById(1L)
+            .orElseThrow(() -> new IllegalArgumentException("플랫폼 관리자 계정 없음"));
+
+    long amount = pay.getAmount();
+    long authorShare = amount * 40 / 100;
+    long derivativeShare = amount * 30 / 100;
+    long platformShare = amount * 30 / 100;
+
+    // ---- RevenueShare 저장 ----
+    revenueShareRepository.save(
+        RevenueShare.builder().pay(pay).author(originalAuthor).shareAmount(authorShare).build());
+
+    revenueShareRepository.save(
+        RevenueShare.builder()
+            .pay(pay)
+            .author(derivativeAuthor)
+            .shareAmount(derivativeShare)
+            .build());
+
+    revenueShareRepository.save(
+        RevenueShare.builder().pay(pay).author(platformAdmin).shareAmount(platformShare).build());
+
+    originalAuthor.setTotalEarned(originalAuthor.getTotalEarned() + authorShare);
+    derivativeAuthor.setTotalEarned(derivativeAuthor.getTotalEarned() + derivativeShare);
+    platformAdmin.setTotalEarned(platformAdmin.getTotalEarned() + platformShare);
+  }
 }

--- a/src/main/java/com/likelion/nextworld/domain/user/entity/User.java
+++ b/src/main/java/com/likelion/nextworld/domain/user/entity/User.java
@@ -43,4 +43,23 @@ public class User {
 
   @Column(name = "updated_at")
   private LocalDateTime updatedAt; // 수정일
+
+  // 포인트 적립
+  public void increasePoints(Long amount) {
+    if (amount == null || amount <= 0) {
+      throw new IllegalArgumentException("적립할 포인트는 0보다 커야 합니다.");
+    }
+    this.pointsBalance += amount;
+  }
+
+  // 포인트 차감
+  public void decreasePoints(Long amount) {
+    if (amount == null || amount <= 0) {
+      throw new IllegalArgumentException("차감할 포인트는 0보다 커야 합니다.");
+    }
+    if (this.pointsBalance < amount) {
+      throw new IllegalArgumentException("보유 포인트가 부족합니다.");
+    }
+    this.pointsBalance -= amount;
+  }
 }


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #11 

## 📝 작업 내용
- 환불 요청을 관리자 승인 후 실제 환불 처리되도록 구현

## 🛠 개발 상세
- 사용자 환불 요청 시 결제 상태만 REFUND_REQUESTED로 변경
- 관리자 환불 승인(approveRefund) 시 PortOne API 호출
- PayStatus Enum -> REFUND_REQUESTED 상태 추가
- findByPayStatus() 메서드 추가로 관리자 환불 요청 조회 지원
- RevenueService, User -> 포인트 차감

## ✔️ 체크 리스트
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?
- [x] 포스트맨으로 API 테스트 통과