### PR TITLE
[REFACTOR] post,work 서비스를 userid 기반으로 변경

### DIFF
--- a/src/main/java/com/likelion/nextworld/domain/post/entity/Post.java
+++ b/src/main/java/com/likelion/nextworld/domain/post/entity/Post.java
@@ -1,10 +1,12 @@
 package com.likelion.nextworld.domain.post.entity;
 
-import com.likelion.nextworld.domain.user.entity.User;
-import jakarta.persistence.*;
-import lombok.*;
-
 import java.time.LocalDateTime;
+
+import jakarta.persistence.*;
+
+import com.likelion.nextworld.domain.user.entity.User;
+
+import lombok.*;
 
 @Entity
 @Getter
@@ -13,57 +15,56 @@ import java.time.LocalDateTime;
 @Builder
 public class Post {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    @Setter
-    private String title;
+  @Setter private String title;
 
-    @Setter
-    @Column(columnDefinition = "TEXT")
-    private String content;
+  @Setter
+  @Column(columnDefinition = "TEXT")
+  private String content;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User author;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private User author;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "dauthor_id")
-    private User dAuthor;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "dauthor_id")
+  private User dAuthor;
 
-    @Setter
-    @Enumerated(EnumType.STRING)
-    private WorkStatus status; // DRAFT or PUBLISHED
+  @Setter
+  @Enumerated(EnumType.STRING)
+  private WorkStatus status; // DRAFT or PUBLISHED
 
-    @Enumerated(EnumType.STRING)
-    private WorkType workType; // SHORT, SERIALIZED
+  @Enumerated(EnumType.STRING)
+  private WorkType workType; // SHORT, SERIALIZED
 
-    @Enumerated(EnumType.STRING)
-    private CreationType creationType; // ORIGINAL, DERIVATIVE
+  @Enumerated(EnumType.STRING)
+  private CreationType creationType; // ORIGINAL, DERIVATIVE
 
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
 
-    @PrePersist
-    public void onCreate() {
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
-        if (this.status == null) this.status = WorkStatus.DRAFT;
-    }
+  @PrePersist
+  public void onCreate() {
+    this.createdAt = LocalDateTime.now();
+    this.updatedAt = LocalDateTime.now();
+    if (this.status == null) this.status = WorkStatus.DRAFT;
+  }
 
-    @PreUpdate
-    public void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
-    }
+  @PreUpdate
+  public void onUpdate() {
+    this.updatedAt = LocalDateTime.now();
+  }
 
-    //  1차 창작물과의 연결 (핵심)
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "work_id")
-    private Work parentWork;
+  //  1차 창작물과의 연결 (핵심)
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "work_id")
+  private Work parentWork;
 
-    //  연관관계 편의 메서드 추가
-    public void setParentWork(Work work) {
-        this.parentWork = work;
-    }
+  //  연관관계 편의 메서드 추가
+  public void setParentWork(Work work) {
+    this.parentWork = work;
+  }
 }

--- a/src/main/java/com/likelion/nextworld/domain/post/service/PostService.java
+++ b/src/main/java/com/likelion/nextworld/domain/post/service/PostService.java
@@ -34,10 +34,10 @@ public class PostService {
       throw new IllegalArgumentException("유효하지 않은 토큰 형식입니다.");
     }
     String actualToken = token.substring(7);
-    String email = jwtTokenProvider.getEmailFromToken(actualToken);
+    Long userId = jwtTokenProvider.getUserIdFromToken(actualToken);
 
     return userRepository
-        .findByEmail(email)
+        .findById(userId)
         .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
   }
 

--- a/src/main/java/com/likelion/nextworld/domain/post/service/WorkService.java
+++ b/src/main/java/com/likelion/nextworld/domain/post/service/WorkService.java
@@ -31,10 +31,10 @@ public class WorkService {
     }
 
     String actualToken = token.substring(7);
-    String email = jwtTokenProvider.getEmailFromToken(actualToken);
+    Long userId = jwtTokenProvider.getUserIdFromToken(actualToken);
 
     return userRepository
-        .findByEmail(email)
+        .findById(userId)
         .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
   }
 
@@ -48,9 +48,9 @@ public class WorkService {
       throw new RuntimeException("Invalid or expired token");
     }
 
-    String email = jwtTokenProvider.getEmailFromToken(token);
+    Long userId = jwtTokenProvider.getUserIdFromToken(token);
     User author =
-        userRepository.findByEmail(email).orElseThrow(() -> new RuntimeException("User not found"));
+        userRepository.findById(userId).orElseThrow(() -> new RuntimeException("User not found"));
 
     Work work = new Work();
     work.setTitle(req.getTitle());


### PR DESCRIPTION
## 🛠 개발 상세
- Post, Work, Revenue 관련 서비스 로직에서 email 기반 인증 → userId 기반으로 변경
- JwtTokenProvider.getUserIdFromToken() 사용하도록 통일
- User 조회 로직 findByEmail → findById 로 교체

## ✔️ 체크 리스트
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?