### PR TITLE
[FEAT] 작가 프로필/작품/포스트 조회 API 구현

### DIFF
--- a/src/main/java/com/likelion/nextworld/domain/payment/entity/Pay.java
+++ b/src/main/java/com/likelion/nextworld/domain/payment/entity/Pay.java
@@ -6,11 +6,13 @@ import jakarta.persistence.*;
 
 import com.likelion.nextworld.domain.user.entity.User;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
@@ -55,5 +57,28 @@ public class Pay {
 
   public void setStatus(PayStatus status) {
     this.status = status;
+  }
+
+  public static Pay createCharge(User payer, Long amount, String impUid) {
+    Pay pay = new Pay();
+    pay.payer = payer;
+    pay.amount = amount;
+    pay.type = TransactionType.CHARGE;
+    pay.status = PayStatus.PENDING;
+    pay.impUid = impUid;
+    pay.createdAt = LocalDateTime.now();
+    return pay;
+  }
+
+  public static Pay createUse(User payer, Long amount, Long postId, Long workId) {
+    Pay pay = new Pay();
+    pay.payer = payer;
+    pay.amount = amount;
+    pay.type = TransactionType.USE;
+    pay.status = PayStatus.COMPLETED;
+    pay.postId = postId;
+    pay.workId = workId;
+    pay.createdAt = LocalDateTime.now();
+    return pay;
   }
 }

--- a/src/main/java/com/likelion/nextworld/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/likelion/nextworld/domain/payment/service/PaymentService.java
@@ -42,14 +42,8 @@ public class PaymentService {
               throw new IllegalStateException("이미 처리된 결제입니다.");
             });
 
-    Pay pay =
-        Pay.builder()
-            .payer(payer)
-            .amount(req.getAmount())
-            .type(TransactionType.CHARGE)
-            .status(PayStatus.PENDING)
-            .impUid(req.getImpUid())
-            .build();
+    Pay pay = Pay.createCharge(payer, req.getAmount(), req.getImpUid());
+
     payRepository.save(pay);
   }
 
@@ -82,15 +76,7 @@ public class PaymentService {
 
     payer.setPointsBalance(payer.getPointsBalance() - req.getAmount());
 
-    Pay pay =
-        Pay.builder()
-            .payer(payer)
-            .amount(req.getAmount())
-            .type(TransactionType.USE)
-            .status(PayStatus.COMPLETED)
-            .postId(req.getPostId())
-            .workId(req.getDerivativeWorkId())
-            .build();
+    Pay pay = Pay.createUse(payer, req.getAmount(), req.getPostId(), req.getDerivativeWorkId());
 
     payRepository.save(pay);
   }

--- a/src/main/java/com/likelion/nextworld/domain/post/entity/Post.java
+++ b/src/main/java/com/likelion/nextworld/domain/post/entity/Post.java
@@ -1,6 +1,8 @@
 package com.likelion.nextworld.domain.post.entity;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import jakarta.persistence.*;
 
@@ -82,6 +84,9 @@ public class Post {
 
   @Column(name = "updated_at")
   private LocalDateTime updatedAt;
+
+  @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<PostTag> tags = new ArrayList<>();
 
   @PrePersist
   public void onCreate() {

--- a/src/main/java/com/likelion/nextworld/domain/post/entity/Work.java
+++ b/src/main/java/com/likelion/nextworld/domain/post/entity/Work.java
@@ -61,6 +61,9 @@ public class Work {
   @Column(name = "updated_at")
   private LocalDateTime updatedAt;
 
+  @OneToMany(mappedBy = "work", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<WorkTag> tags = new ArrayList<>();
+
   @PrePersist
   public void onCreate() {
     this.createdAt = LocalDateTime.now();

--- a/src/main/java/com/likelion/nextworld/domain/user/controller/AuthorController.java
+++ b/src/main/java/com/likelion/nextworld/domain/user/controller/AuthorController.java
@@ -1,0 +1,34 @@
+package com.likelion.nextworld.domain.user.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.likelion.nextworld.domain.user.service.AuthorService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/author")
+@RequiredArgsConstructor
+public class AuthorController {
+
+  private final AuthorService authorService;
+
+  @GetMapping("/{authorId}/profile")
+  public ResponseEntity<?> getProfile(@PathVariable Long authorId) {
+    return ResponseEntity.ok(authorService.getAuthorProfile(authorId));
+  }
+
+  @GetMapping("/{authorId}/works")
+  public ResponseEntity<?> getWorks(@PathVariable Long authorId) {
+    return ResponseEntity.ok(authorService.getAuthorWorks(authorId));
+  }
+
+  @GetMapping("/{authorId}/posts")
+  public ResponseEntity<?> getPosts(@PathVariable Long authorId) {
+    return ResponseEntity.ok(authorService.getAuthorPosts(authorId));
+  }
+}

--- a/src/main/java/com/likelion/nextworld/domain/user/dto/AuthorPostResponse.java
+++ b/src/main/java/com/likelion/nextworld/domain/user/dto/AuthorPostResponse.java
@@ -1,0 +1,16 @@
+package com.likelion.nextworld.domain.user.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AuthorPostResponse {
+  private Long postId;
+  private Long workId;
+  private String title;
+  private String thumbnailUrl;
+  private List<String> tags;
+}

--- a/src/main/java/com/likelion/nextworld/domain/user/dto/AuthorProfileResponse.java
+++ b/src/main/java/com/likelion/nextworld/domain/user/dto/AuthorProfileResponse.java
@@ -1,0 +1,15 @@
+package com.likelion.nextworld.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AuthorProfileResponse {
+  private Long authorId;
+  private String nickname;
+  private String bio;
+  private String contactEmail;
+  private String twitter;
+  private String profileImageUrl;
+}

--- a/src/main/java/com/likelion/nextworld/domain/user/dto/AuthorWorkResponse.java
+++ b/src/main/java/com/likelion/nextworld/domain/user/dto/AuthorWorkResponse.java
@@ -1,0 +1,17 @@
+package com.likelion.nextworld.domain.user.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AuthorWorkResponse {
+  private Long workId;
+  private String title;
+  private String coverImageUrl;
+  private String category;
+  private String workType;
+  private List<String> tags;
+}

--- a/src/main/java/com/likelion/nextworld/domain/user/entity/User.java
+++ b/src/main/java/com/likelion/nextworld/domain/user/entity/User.java
@@ -38,6 +38,10 @@ public class User {
   @Column(name = "points_balance", nullable = false)
   private Long pointsBalance; // 현재 보유 포인트
 
+  @Builder.Default
+  @Column(name = "total_earned")
+  private Long totalEarned = 0L; // 총 수익
+
   @Column(name = "created_at", nullable = false)
   private LocalDateTime createdAt; // 가입일
 

--- a/src/main/java/com/likelion/nextworld/domain/user/service/AuthorService.java
+++ b/src/main/java/com/likelion/nextworld/domain/user/service/AuthorService.java
@@ -1,0 +1,93 @@
+package com.likelion.nextworld.domain.user.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.likelion.nextworld.domain.post.entity.Post;
+import com.likelion.nextworld.domain.post.entity.Work;
+import com.likelion.nextworld.domain.post.entity.WorkStatus;
+import com.likelion.nextworld.domain.post.repository.PostRepository;
+import com.likelion.nextworld.domain.post.repository.WorkRepository;
+import com.likelion.nextworld.domain.user.dto.AuthorPostResponse;
+import com.likelion.nextworld.domain.user.dto.AuthorProfileResponse;
+import com.likelion.nextworld.domain.user.dto.AuthorWorkResponse;
+import com.likelion.nextworld.domain.user.entity.User;
+import com.likelion.nextworld.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthorService {
+
+  private final UserRepository userRepository;
+  private final WorkRepository workRepository;
+  private final PostRepository postRepository;
+
+  public AuthorProfileResponse getAuthorProfile(Long authorId) {
+    User author =
+        userRepository
+            .findById(authorId)
+            .orElseThrow(() -> new IllegalArgumentException("작가를 찾을 수 없습니다."));
+
+    return AuthorProfileResponse.builder()
+        .authorId(author.getUserId())
+        .nickname(author.getNickname())
+        .bio(author.getBio())
+        .contactEmail(author.getContactEmail())
+        .twitter(author.getTwitter())
+        .profileImageUrl(author.getProfileImageUrl())
+        .build();
+  }
+
+  public List<AuthorWorkResponse> getAuthorWorks(Long authorId) {
+
+    List<Work> works = workRepository.findByAuthorUserId(authorId);
+
+    return works.stream()
+        .map(
+            work -> {
+              List<String> tags =
+                  work.getTags().stream().map(workTag -> workTag.getTag().getName()).toList();
+
+              return AuthorWorkResponse.builder()
+                  .workId(work.getId())
+                  .title(work.getTitle())
+                  .coverImageUrl(work.getCoverImageUrl())
+                  .category(work.getCategory())
+                  .workType(work.getWorkType().name())
+                  .tags(tags)
+                  .build();
+            })
+        .toList();
+  }
+
+  public List<AuthorPostResponse> getAuthorPosts(Long authorId) {
+
+    User author =
+        userRepository
+            .findById(authorId)
+            .orElseThrow(() -> new IllegalArgumentException("작가를 찾을 수 없습니다."));
+
+    List<Post> posts = postRepository.findByAuthorAndStatus(author, WorkStatus.PUBLISHED);
+
+    return posts.stream()
+        .map(
+            post -> {
+              String thumbnail = post.getWork() != null ? post.getWork().getCoverImageUrl() : null;
+
+              List<String> tags =
+                  post.getTags().stream().map(postTag -> postTag.getTag().getName()).toList();
+
+              return AuthorPostResponse.builder()
+                  .postId(post.getId())
+                  .workId(post.getWork() != null ? post.getWork().getId() : null)
+                  .title(post.getTitle())
+                  .thumbnailUrl(thumbnail)
+                  .tags(tags)
+                  .build();
+            })
+        .toList();
+  }
+}


### PR DESCRIPTION
## 📝 작업 내용
- 작가 프로필 조회 API 구현 (닉네임, 소개, SNS, 프로필 이미지 등)
- 작가가 창작한 작품 목록 조회 API 구현
- 작가가 작성한 포스트 목록 조회 API 구현
- Work / Post 엔티티 기반으로 태그 포함한 DTO 응답 구성
- AuthorService & AuthorController 생성 및 도메인 구조 정리

## 🛠 개발 상세
- user_id 기반으로 작가 정보 조회
- workRepository.findByAuthorUserId() 를 이용해 작가의 작품 리스트 반환
- 포스트는 postRepository.findByAuthorAndStatus(PUBLISHED) 로 필터링하여 회차/단편만 조회
- WorkTag / PostTag 를 활용하여 태그 리스트를 이름(String)으로 매핑
- 응답 DTO (AuthorProfileResponse, AuthorWorkResponse, AuthorPostResponse) 구성

## ✔️ 체크 리스트
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?
